### PR TITLE
CSS mucking about

### DIFF
--- a/.github/workflows/package.json
+++ b/.github/workflows/package.json
@@ -9,7 +9,7 @@
     "display_name": "HTML Settings Export Reborn",
     "package_id": "HTMLSettingsExportReborn",
     "package_type": "plugin",
-    "package_version": "1.2.1",
+    "package_version": "1.2.2",
     "sdk_version": 8,
     "sdk_version_semver": "8.0.0",
     "website": "https://github.com/Slashee-the-Cow/HTMLSettingsExportReborn/"

--- a/HTMLSettingsExportReborn.py
+++ b/HTMLSettingsExportReborn.py
@@ -5,6 +5,8 @@
 # https://github.com/5axes/CuraHtmlDoc/
 #--------------------------------------------------------------------------------------------------
 # Version history (Reborn edition)
+# v1.2.2:
+#   - Messed around with CSS rules to fix display problems when filtering and searching (that's literally it, this note is the only change in the .py file).
 # v1.2.1:
 #   - Fixed up some CSS with which I may have gotten a bit too careless using search + replace before.
 #   - Wrapped CSS class names in double hyphens to avoid collisions.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ I want to know about it! Just jump by the [GitHub repo](https://github.com/slash
 
 ---
 ### Version History
+#### v1.2.2:
+- Fixed some output display problems when using filters and searching.
 #### v1.2.1:
 - Minor bug fixes.
 #### v1.2.0:
@@ -55,3 +57,4 @@ I want to know about it! Just jump by the [GitHub repo](https://github.com/slash
 
 ### Known Issues
 - Formatting of the "machine settings" section might result in narrow columns of the setting values with text wrapping across several lines.
+- Depending on active filters and search terms, catgories with empty tables may show up when searching while filters are active.

--- a/html_start.html
+++ b/html_start.html
@@ -130,18 +130,32 @@
 
 			/* Hide row types depending on user selection */
 			body.hide-disabled tr.--disabled-- { display: none; }
-			body.hide-local tr:not(.--local--, .--some-local--) { display: none; }
+			body.hide-disabled details:not(:has(tr.--disabled--)) {
+				 display: none;  /* Hide <details> block if it contains no user changed settings */
+			}
+			body.hide-local table.--category-- > tbody > tr:not(.--local--, .--some-local--) { display: none; }
 			body.hide-local details:not(:has(tr.--local--, tr.--some-local--)) {
 				 display: none;  /* Hide <details> block if it contains no user changed settings */
 			}
-			body.hide-diff tr:not(.--compare-diff--) { display: none; }
+			body.hide-diff table.--category-- > tbody > tr:not(.--compare-diff--) { display: none; }
 			body.hide-diff details:not(:has(tr.--compare-diff--)) {
-				 display: none;  /* Hide <details> block if it contains no user different settings */
+				 display: none;  /* Hide <details> block if it contains no different settings */
 			}
 
 			body.search-active details:not(:has(tr.search-show)) {
 				 display: none !important; /* Hide <details> block if it contains no search results */
 			}
+
+			body.search-active.hide-disabled details:not(:has(tr.search-show:not(.--disabled--))) {
+				display: none !important;
+			}
+			body.search-active.hide-local details:not(:has(tr.search-show.--local--, tr.search-show.--some-local--)) {
+				display: none !important;
+			}
+			body.search-active.hide-diff details:not(:has(tr.search-show.--compare-diff--)) {
+				display: none !important;
+			}
+			
 
 			/* Make <summary> display a pointer (like a link) so it's
 				obvious it can be clicked and set background colour */
@@ -210,12 +224,12 @@
 			}
 			/* I know !important is bad semantically but it's easier
 			than coming up with a more specific but not fragile selector */
-			tr.search-hide {
-				display: none !important;
-			}
-			tr.search-show {
-				display: table-row !important;
-			}
+			tr.search-hide { display: none !important; }
+			tr.search-show { display: table-row !important; }
+			/* It's bad semantically because now I need more specific rules for other filters */
+			body.search-active.hide-disabled tr.--disabled--.search-show { display: none !important; }
+			body.search-active.hide-local table.--category-- > tbody > tr.search-show:not(.--local--, .--some-local--) { display: none !important; }
+			body.search-active.hide-diff table.--category-- > tbody > tr.search-show:not(.--compare-diff--) { display: none !important; }
 		</style>
 	</head>
 	<body>

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "HTML Settings Export Reborn",
     "author": "Slashee the Cow",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Export a HTML file with current print quality settings for easy reference later.",
     "api": 8,
     "minimum_cura_version": "5.0",


### PR DESCRIPTION
Hopefully don't hide table headings. And only show a <details> block with a search active but all settings are filtered out if they're filtered out due to different filters.